### PR TITLE
fixed：table opts error

### DIFF
--- a/src/Traits/FormatOutputAwareTrait.php
+++ b/src/Traits/FormatOutputAwareTrait.php
@@ -192,9 +192,9 @@ trait FormatOutputAwareTrait
      * @inheritdoc
      * @see Show::table()
      */
-    public function table(array $data, $title = 'Data Table', $showBorder = true): void
+    public function table(array $data, $title = 'Data Table', array $opts = []): void
     {
-        Show::table($data, $title, ['showBorder' => $showBorder]);
+        Show::table($data, $title, $opts);
     }
 
     /**


### PR DESCRIPTION
原来的代码只能修改`showBorder`，使用`$output->table()`这个的时候就不对了
```
array(10) {
  ["showBorder"]=>
  array(2) {
    ["showBorder"]=>
    bool(true)
    ["columns"]=>
    array(3) {
      [0]=>
      string(2) "ID"
      [1]=>
      string(12) "时间"
      [2]=>
      string(6) "邮箱"
    }
  }
  ["leftIndent"]=>
  string(2) "  "
  ["titlePos"]=>
  string(1) "l"
  ["titleStyle"]=>
  string(4) "bold"
  ["headStyle"]=>
  string(7) "comment"
  ["headBorderChar"]=>
  string(1) "="
  ["bodyStyle"]=>
  string(0) ""
  ["rowBorderChar"]=>
  string(1) "-"
  ["colBorderChar"]=>
  string(1) "|"
  ["columns"]=>
  array(0) {
  }
}
```