### PR TITLE
用mb_strwidth代替mb_strlen来测量字符串宽度，便于表格显示

### DIFF
--- a/src/Component/Formatter/Table.php
+++ b/src/Component/Formatter/Table.php
@@ -131,7 +131,7 @@ class Table extends MessageFormatter
                         $hasHead = true;
                     }
 
-                    $info['columnMaxWidth'][$index] = mb_strlen($name, 'UTF-8');
+                    $info['columnMaxWidth'][$index] = mb_strwidth($name, 'UTF-8');
                 }
             }
 
@@ -140,14 +140,14 @@ class Table extends MessageFormatter
             foreach ((array)$row as $value) {
                 // collection column max width
                 if (isset($info['columnMaxWidth'][$colIndex])) {
-                    $colWidth = mb_strlen($value, 'UTF-8');
+                    $colWidth = mb_strwidth($value, 'UTF-8');
 
                     // If current column width gt old column width. override old width.
                     if ($colWidth > $info['columnMaxWidth'][$colIndex]) {
                         $info['columnMaxWidth'][$colIndex] = $colWidth;
                     }
                 } else {
-                    $info['columnMaxWidth'][$colIndex] = mb_strlen($value, 'UTF-8');
+                    $info['columnMaxWidth'][$colIndex] = mb_strwidth($value, 'UTF-8');
                 }
 
                 $colIndex++;
@@ -163,7 +163,7 @@ class Table extends MessageFormatter
         if ($title) {
             $tStyle      = $opts['titleStyle'] ?: 'bold';
             $title       = ucwords(trim($title));
-            $titleLength = mb_strlen($title, 'UTF-8');
+            $titleLength = mb_strwidth($title, 'UTF-8');
             $indentSpace = Str::pad(' ', ceil($tableWidth / 2) - ceil($titleLength / 2) + ($columnCount * 2), ' ');
             $buf->write("  {$indentSpace}<$tStyle>{$title}</$tStyle>\n");
         }
@@ -184,7 +184,7 @@ class Table extends MessageFormatter
             foreach ($head as $index => $name) {
                 $colMaxWidth = $info['columnMaxWidth'][$index];
                 // format
-                $name    = Str::pad($name, $colMaxWidth, ' ');
+                $name    = self::padByWidth($name, $colMaxWidth); // Str::pad($name, $colMaxWidth, ' ');
                 $name    = ColorTag::wrap($name, $opts['headStyle']);
                 $headStr .= " {$name} {$colBorderChar}";
             }
@@ -212,7 +212,7 @@ class Table extends MessageFormatter
             foreach ((array)$row as $value) {
                 $colMaxWidth = $info['columnMaxWidth'][$colIndex];
                 // format
-                $value  = Str::pad($value, $colMaxWidth, ' ');
+                $value  = self::padByWidth($value, $colMaxWidth);
                 $value  = ColorTag::wrap($value, $opts['bodyStyle']);
                 $rowStr .= " {$value} {$colBorderChar}";
                 $colIndex++;
@@ -228,5 +228,9 @@ class Table extends MessageFormatter
         }
 
         return Console::write($buf);
+    }
+
+    public static function padByWidth(string $value,int $padLen, $padStr = ' ') {
+         return $value . str_repeat($padStr, $padLen - mb_strwidth($value, 'UTF-8'));
     }
 }

--- a/src/Component/Formatter/Table.php
+++ b/src/Component/Formatter/Table.php
@@ -162,7 +162,7 @@ class Table extends MessageFormatter
         // output title
         if ($title) {
             $tStyle      = $opts['titleStyle'] ?: 'bold';
-            $title       = ucwords(trim($title));
+            $title       = mb_convert_case(trim($title),MB_CASE_TITLE);
             $titleLength = mb_strwidth($title, 'UTF-8');
             $indentSpace = Str::pad(' ', ceil($tableWidth / 2) - ceil($titleLength / 2) + ($columnCount * 2), ' ');
             $buf->write("  {$indentSpace}<$tStyle>{$title}</$tStyle>\n");
@@ -184,7 +184,7 @@ class Table extends MessageFormatter
             foreach ($head as $index => $name) {
                 $colMaxWidth = $info['columnMaxWidth'][$index];
                 // format
-                $name    = self::padByWidth($name, $colMaxWidth); // Str::pad($name, $colMaxWidth, ' ');
+                $name    = self::padByWidth($name, $colMaxWidth);
                 $name    = ColorTag::wrap($name, $opts['headStyle']);
                 $headStr .= " {$name} {$colBorderChar}";
             }


### PR DESCRIPTION
原本使用mb_strlen来测量字符串宽度，在中文环境不太准确，所以当改用mb_strwidth时，能够准确检测出显示时的宽度

而填充时如果使用str_pad，则仍然会因为宽度测量不准确而不能准确填充，所以改为用拼接字符串的形式来填充，缺点是只能在字符串的首尾填充

代码中新增的私有方法(padByWidth)就是用于此类填充，原本考虑加入到StringHelper类中，但考虑到它属于另一个仓库，所以直接加入到了当前类中，建议可以重新封装到合适的类中